### PR TITLE
use relative include instead of Pkg.dir

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,6 @@ using Base.Test
 tol=0.0001;
 
 # test the Three DOF Vehicle Model
-include(Pkg.dir("VehicleModels/test/ThreeDOF.jl"))
+include("ThreeDOF.jl")
 
 @test threeDOF_test1() ≈ 0 atol=tol


### PR DESCRIPTION
Pkg.dir is incorrect if the package is installed and loaded from
somewhere else on LOAD_PATH